### PR TITLE
Update entry point for essay request flow

### DIFF
--- a/src/flow.flex.yaml
+++ b/src/flow.flex.yaml
@@ -25,4 +25,4 @@ inputs:
   skills:
     type: list
     is_chat_input: false
-entry: essay_request:app
+entry: essay_request:essay


### PR DESCRIPTION
This pull request includes a small change to the `inputs:` section in the `src/flow.flex.yaml` file. The change modifies the entry for `skills` from `essay_request:app` to `essay_request:essay`.