### PR TITLE
Increase max_tokens parameter from 128 to 4096 for improved response …

### DIFF
--- a/src/essay.prompty
+++ b/src/essay.prompty
@@ -9,7 +9,7 @@ model:
     type: azure_openai
     azure_deployment: gpt-4
   parameters:
-    max_tokens: 128
+    max_tokens: 4096
     temperature: 0.2
 inputs:
   language:


### PR DESCRIPTION
This pull request includes a change to the `src/essay.prompty` file to adjust the parameters for the Azure OpenAI model.

* [`src/essay.prompty`](diffhunk://#diff-8dcb17084d314b88dc76d799b37be8ba7c910c24c5ce9f96f17a770d58eb68ddL12-R12): Increased the `max_tokens` parameter from 128 to 4096.…generation