### PR TITLE
Return response directly from essay function instead of wrapping in j…

### DIFF
--- a/src/essay_request.py
+++ b/src/essay_request.py
@@ -41,7 +41,7 @@ app = Flask(__name__)
 def essay():
     essay_eval_request = request.get_json()
     response = get_response(essay_eval_request)
-    return jsonify(response)
+    return response
 
 if __name__ == "__main__":
     app.run(port=8080, debug=True)


### PR DESCRIPTION
This pull request includes a small change to the `src/essay_request.py` file. The change modifies the `def get_response(essay_eval_request):` function to return the response directly instead of using `jsonify`. 

* [`src/essay_request.py`](diffhunk://#diff-41c64d77026b7e5f55a210fc850ea5f55ec927ddc60476601c0c01569f22e229L44-R44): Changed the `get_response` function to return the response directly instead of using `jsonify`.…sonify