### PR TITLE
Feature/old essay as class

### DIFF
--- a/src/OLD_ESSAY/old_essay.py
+++ b/src/OLD_ESSAY/old_essay.py
@@ -1,19 +1,26 @@
 import os
 from promptflow.core import Prompty
+from promptflow.core import AzureOpenAIModelConfiguration
 
-def get_response_old_essay(essay_request, model_config):
-    print("inputs:", essay_request)
-    print("getting result...")
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    prompty_path = os.path.join(current_dir, "old_essay.prompty")
-    prompty = Prompty.load(source=prompty_path)
-    result = prompty(
-        language=essay_request["language"],
-        genre=essay_request["genre"],
-        statement=essay_request["statement"],
-        title=essay_request["title"],
-        essay=essay_request["essay"],
-        support_text=essay_request["support_text"],
-        skills=essay_request["skills"]
-    )
-    return result
+class OldEssay:
+    def __init__(self, model_config: AzureOpenAIModelConfiguration):
+        self.current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.prompty_path = os.path.join(self.current_dir, "old_essay.prompty")
+        self.model_config = model_config
+
+    def __call__(self, essay_request: str) -> str:
+        print("inputs:", essay_request)
+        print("getting result...")
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        prompty_path = os.path.join(current_dir, "old_essay.prompty")
+        prompty = Prompty.load(source=prompty_path)
+        result = prompty(
+            language=essay_request["language"],
+            genre=essay_request["genre"],
+            statement=essay_request["statement"],
+            title=essay_request["title"],
+            essay=essay_request["essay"],
+            support_text=essay_request["support_text"],
+            skills=essay_request["skills"]
+        )
+        return result

--- a/src/OLD_ESSAY/old_essay.py
+++ b/src/OLD_ESSAY/old_essay.py
@@ -2,6 +2,7 @@ import os
 from promptflow.core import Prompty
 from promptflow.core import AzureOpenAIModelConfiguration
 
+# class based flow: https://microsoft.github.io/promptflow/how-to-guides/develop-a-flex-flow/class-based-flow.html
 class OldEssay:
     def __init__(self, model_config: AzureOpenAIModelConfiguration):
         self.current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/src/essay_request_router.py
+++ b/src/essay_request_router.py
@@ -8,7 +8,7 @@ from promptflow.tools.common import init_azure_openai_client
 from promptflow.connections import AzureOpenAIConnection
 from promptflow.core import (AzureOpenAIModelConfiguration, Prompty, tool)
 from flask import Flask, request, jsonify
-from OLD_ESSAY.old_essay import get_response_old_essay
+from OLD_ESSAY.old_essay import OldEssay
 from POEMA_FALADO.POEMA_FALADO_1EM_prompt_flow import get_response_poema_falado
 
 @tool
@@ -35,8 +35,9 @@ def get_response(essay_request):
     if essay_type == 'poema_falado':
         result = get_response_poema_falado(essay_request,model_config)
     elif essay_type == 'old_essay':
-        result = get_response_old_essay(essay_request, model_config)
-
+        #result = get_response_old_essay(essay_request, model_config)
+        old_essay = OldEssay(model_config)
+        result = old_essay(essay_request)
 
     return result
 

--- a/src/essay_request_router.py
+++ b/src/essay_request_router.py
@@ -35,7 +35,7 @@ def get_response(essay_request):
     if essay_type == 'poema_falado':
         result = get_response_poema_falado(essay_request,model_config)
     elif essay_type == 'old_essay':
-        #result = get_response_old_essay(essay_request, model_config)
+        #calling using class based flow
         old_essay = OldEssay(model_config)
         result = old_essay(essay_request)
 


### PR DESCRIPTION
This pull request refactors the `OLD_ESSAY` module to use a class-based flow and updates the `essay_request_router` accordingly. The main changes include the introduction of the `OldEssay` class and the modification of the `get_response` function to use this new class.

Refactoring to class-based flow:

* [`src/OLD_ESSAY/old_essay.py`](diffhunk://#diff-5d5b4b064b93e1896a6814b96925629021423929bce49df8125174e7bacd1447R3-R12): Introduced the `OldEssay` class, which encapsulates the logic for handling essay requests using the `AzureOpenAIModelConfiguration`.

Updates to `essay_request_router`:

* [`src/essay_request_router.py`](diffhunk://#diff-9f8a803a31d8fa87d62568f8abb7b347f61ea25a7c86c2025794b962d7adc386L11-R11): Updated the import statement to use the `OldEssay` class instead of the `get_response_old_essay` function.
* [`src/essay_request_router.py`](diffhunk://#diff-9f8a803a31d8fa87d62568f8abb7b347f61ea25a7c86c2025794b962d7adc386L38-R40): Modified the `get_response` function to instantiate and use the `OldEssay` class for handling `old_essay` type requests.